### PR TITLE
Polish collapsible API settings for v0.1.5

### DIFF
--- a/src/me_finder/static/app.css
+++ b/src/me_finder/static/app.css
@@ -1119,7 +1119,19 @@ html[data-desktop-shell="macos"] .main-area {
   cursor: pointer;
 }
 .settings-collapse-head .settings-section-title { flex: 1; }
+.settings-collapse-head-detailed .settings-section-title { flex: 0 0 auto; }
 .settings-collapse-head:hover .settings-section-title { color: var(--accent); }
+.settings-collapse-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-height: 34px;
+}
+.settings-collapse-row .settings-collapse-head {
+  flex: 1;
+  min-width: 0;
+  width: auto;
+}
 .settings-grid {
   display: grid;
   grid-template-columns: 150px minmax(0, 1fr);
@@ -1149,6 +1161,8 @@ html[data-desktop-shell="macos"] .main-area {
 }
 .settings-collapse.expanded .settings-collapse-chevron { transform: rotate(180deg); }
 .settings-collapse-body { container-type: inline-size; margin-top: 18px; }
+.settings-collapse-body > .settings-grid:first-child,
+.settings-collapse-body > .vision-provider-layout:first-child { margin-top: 0; }
 .settings-current-theme {
   flex: 0 0 auto;
   display: inline-flex;
@@ -1556,7 +1570,30 @@ html[data-desktop-shell="macos"] .macos-pdf-settings { display: block; }
 .vision-policy-copy { display: grid; gap: 3px; }
 .vision-policy-copy strong { color: var(--text-primary); font-size: 13px; }
 .vision-policy-copy small { color: var(--text-tertiary); font-size: 11px; line-height: 1.45; }
-.vision-default-select { background: var(--input-bg); }
+.vision-default-select-wrap {
+  position: relative;
+  display: block;
+  min-width: 0;
+}
+.vision-default-select {
+  -webkit-appearance: none;
+  appearance: none;
+  padding-right: 34px;
+  background: var(--input-bg);
+  cursor: pointer;
+}
+.vision-default-select:hover { border-color: var(--border-strong); }
+.vision-default-select-chevron {
+  position: absolute;
+  top: 50%;
+  right: 10px;
+  width: 16px;
+  height: 16px;
+  color: var(--text-tertiary);
+  pointer-events: none;
+  transform: translateY(-50%);
+}
+.vision-default-select-wrap:focus-within .vision-default-select-chevron { color: var(--accent); }
 .vision-auto-check { white-space: nowrap; }
 @media (max-width: 960px) {
   .vision-fallback-policy { grid-template-columns: 1fr 1fr; }

--- a/src/me_finder/static/app.js
+++ b/src/me_finder/static/app.js
@@ -1948,15 +1948,35 @@ function updateAppearanceSummary() {
   el.innerHTML = '<span class="settings-theme-dot"></span>' + esc(current ? current.name : '');
 }
 
-function toggleAppearance() {
-  var card = document.getElementById('appearance-card');
-  var body = document.getElementById('appearance-body');
+function setSettingsCollapse(cardId, bodyId, open) {
+  var card = document.getElementById(cardId);
+  var body = document.getElementById(bodyId);
   var head = card ? card.querySelector('.settings-collapse-head') : null;
   if (!card || !body) return;
-  var open = body.style.display === 'none';
   body.style.display = open ? 'block' : 'none';
   card.classList.toggle('expanded', open);
   if (head) head.setAttribute('aria-expanded', open ? 'true' : 'false');
+}
+
+function toggleSettingsCollapse(cardId, bodyId) {
+  var body = document.getElementById(bodyId);
+  if (!body) return;
+  setSettingsCollapse(cardId, bodyId, body.style.display === 'none');
+}
+
+function toggleAppearance() {
+  toggleSettingsCollapse('appearance-card', 'appearance-body');
+}
+
+function openVisionSettings() {
+  navigateTo('settings');
+  setSettingsCollapse('vision-settings-card', 'vision-settings-body', true);
+  var card = document.getElementById('vision-settings-card');
+  if (card) requestAnimationFrame(function() {
+    card.scrollIntoView({behavior: 'smooth', block: 'start'});
+    var head = card.querySelector('.settings-collapse-head');
+    if (head) head.focus({preventScroll: true});
+  });
 }
 
 function renderPdfOpenMode() {
@@ -2799,6 +2819,7 @@ function resetVisionProviderForm() {
 }
 
 function startAddVisionProvider() {
+  setSettingsCollapse('vision-settings-card', 'vision-settings-body', true);
   resetVisionProviderForm();
   var card = document.getElementById('vision-editor-card');
   if (card) card.scrollIntoView({behavior: 'smooth', block: 'nearest'});
@@ -3385,7 +3406,7 @@ async function retryImportWithVision(id) {
   if (!q || !q.jobId) return;
   var providerId = q.retryProviderId || visionConfig.default_provider_id || selectedVisionProviderId();
   if (!providerId) {
-    navigateTo('settings');
+    openVisionSettings();
     showToast('请先配置一个其他解析 API');
     return;
   }

--- a/src/me_finder/templates/index.html
+++ b/src/me_finder/templates/index.html
@@ -307,7 +307,7 @@
               <strong>其他视觉 API</strong>
               <small>使用设置中保存的 OpenAI 兼容视觉模型逐页解析。</small>
               <select id="import-vision-provider" class="pdf-provider-select" onclick="event.stopPropagation()" onchange="document.querySelector('input[name=&quot;pdf-parse-mode&quot;][value=&quot;vision&quot;]').checked=true" aria-label="选择其他解析 API"></select>
-              <a id="vision-parse-config-link" class="pdf-provider-config-link" href="javascript:void(0)" onclick="event.stopPropagation();navigateTo('settings')" hidden>尚未配置，去设置里添加接口 →</a>
+              <a id="vision-parse-config-link" class="pdf-provider-config-link" href="javascript:void(0)" onclick="event.stopPropagation();openVisionSettings()" hidden>尚未配置，去设置里添加接口 →</a>
             </span>
           </label>
         </div>
@@ -386,13 +386,15 @@
             </label>
           </div>
         </section>
-        <section class="settings-section">
-          <div class="settings-section-head">
+        <section class="settings-section settings-collapse" id="mineru-settings-card">
+          <button class="settings-section-head settings-collapse-head settings-collapse-head-detailed" type="button" aria-expanded="false" aria-controls="mineru-settings-body" onclick="toggleSettingsCollapse('mineru-settings-card','mineru-settings-body')">
             <span class="settings-section-title">MinerU API</span>
             <span class="settings-section-note">用于扫描版、乱码或复杂排版 PDF 的精准解析</span>
             <span id="mineru-config-status" class="settings-status">读取中…</span>
-          </div>
-          <div class="settings-grid">
+            <svg class="settings-collapse-chevron" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 8 4 4 4-4"/></svg>
+          </button>
+          <div class="settings-collapse-body" id="mineru-settings-body" style="display:none">
+            <div class="settings-grid">
             <label class="settings-label" for="mineru-token">Bearer Token</label>
             <div class="settings-control">
               <div class="settings-input-row">
@@ -432,16 +434,21 @@
               <button class="action-btn" type="button" onclick="loadMineruConfig()">重新读取</button>
               <span id="mineru-save-hint" class="settings-hint">密钥只保存在本机。</span>
             </div>
+            </div>
           </div>
         </section>
-        <section class="settings-section">
-          <div class="settings-section-head">
-            <span class="settings-section-title">其他解析 API</span>
-            <span class="settings-section-note">可选的 OpenAI 兼容视觉模型与中转接口</span>
-            <span id="vision-config-status" class="settings-status">读取中…</span>
+        <section class="settings-section settings-collapse" id="vision-settings-card">
+          <div class="settings-collapse-row">
+            <button class="settings-section-head settings-collapse-head settings-collapse-head-detailed" type="button" aria-expanded="false" aria-controls="vision-settings-body" onclick="toggleSettingsCollapse('vision-settings-card','vision-settings-body')">
+              <span class="settings-section-title">其他解析 API</span>
+              <span class="settings-section-note">可选的 OpenAI 兼容视觉模型与中转接口</span>
+              <span id="vision-config-status" class="settings-status">读取中…</span>
+              <svg class="settings-collapse-chevron" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 8 4 4 4-4"/></svg>
+            </button>
             <button class="action-btn vision-add-btn" type="button" onclick="startAddVisionProvider()"><svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><path d="M10 4.5v11M4.5 10h11"/></svg><span>添加接口</span></button>
           </div>
-          <div class="vision-provider-layout">
+          <div class="settings-collapse-body" id="vision-settings-body" style="display:none">
+            <div class="vision-provider-layout">
             <div id="vision-provider-list" class="vision-provider-list"></div>
             <div class="vision-editor-card" id="vision-editor-card">
               <div class="vision-editor-head">
@@ -499,19 +506,23 @@
                 </div>
               </div>
             </div>
-          </div>
-          <div class="vision-fallback-policy">
-            <div class="vision-policy-copy">
-              <strong>MinerU 失败后的处理</strong>
-              <small>默认只提示失败，开启后会自动改用默认备用接口重试。</small>
             </div>
-            <select id="vision-default-provider" class="settings-input vision-default-select" aria-label="默认备用接口"></select>
-            <label class="ui-switch vision-auto-check">
-              <input id="vision-auto-fallback" type="checkbox">
-              <span class="ui-switch-track" aria-hidden="true"></span>
-              <span class="ui-switch-text">MinerU 失败时自动切换</span>
-            </label>
-            <button class="action-btn" type="button" onclick="saveVisionPolicy()">保存切换设置</button>
+            <div class="vision-fallback-policy">
+              <div class="vision-policy-copy">
+                <strong>MinerU 失败后的处理</strong>
+                <small>默认只提示失败，开启后会自动改用默认备用接口重试。</small>
+              </div>
+              <span class="vision-default-select-wrap">
+                <select id="vision-default-provider" class="settings-input vision-default-select" aria-label="默认备用接口"></select>
+                <svg class="vision-default-select-chevron" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 8 4 4 4-4"/></svg>
+              </span>
+              <label class="ui-switch vision-auto-check">
+                <input id="vision-auto-fallback" type="checkbox">
+                <span class="ui-switch-track" aria-hidden="true"></span>
+                <span class="ui-switch-text">MinerU 失败时自动切换</span>
+              </label>
+              <button class="action-btn" type="button" onclick="saveVisionPolicy()">保存切换设置</button>
+            </div>
           </div>
         </section>
         <section class="settings-section">

--- a/tests/test_search_controls_and_views.py
+++ b/tests/test_search_controls_and_views.py
@@ -92,6 +92,23 @@ class SearchControlsAndViewsTests(unittest.TestCase):
         self.assertIn('summary.get("auto_fallback_from_mineru")', WEB_SOURCE)
         self.assertIn("can_retry_with_provider=bool(fallback)", WEB_SOURCE)
 
+    def test_api_settings_collapse_and_fallback_select_match_the_app_style(self) -> None:
+        self.assertIn('id="mineru-settings-card"', HTML)
+        self.assertIn('aria-controls="mineru-settings-body"', HTML)
+        self.assertIn('id="mineru-settings-body" style="display:none"', HTML)
+        self.assertIn('id="vision-settings-card"', HTML)
+        self.assertIn('aria-controls="vision-settings-body"', HTML)
+        self.assertIn('id="vision-settings-body" style="display:none"', HTML)
+        self.assertIn("function toggleSettingsCollapse(cardId, bodyId)", HTML)
+        self.assertIn("setSettingsCollapse('vision-settings-card', 'vision-settings-body', true)", HTML)
+        self.assertIn('class="vision-default-select-wrap"', HTML)
+        self.assertIn('id="vision-default-provider"', HTML)
+        self.assertIn('class="vision-default-select-chevron"', HTML)
+        self.assertIn("-webkit-appearance: none;", HTML)
+        self.assertIn("appearance: none;", HTML)
+        self.assertIn("openVisionSettings()", HTML)
+        self.assertIn("head.focus({preventScroll: true})", HTML)
+
     def test_vision_models_can_be_discovered_or_entered_manually(self) -> None:
         self.assertIn('id="vision-model"', HTML)
         self.assertIn('id="vision-model-pop"', HTML)


### PR DESCRIPTION
## What changed

- Make the MinerU API and optional vision API sections collapsible, matching the existing appearance section.
- Keep configuration status visible while the forms are collapsed.
- Replace the macOS native 3D select bezel in the MinerU fallback policy with the app's flat 2D styling and chevron.
- Automatically expand and focus the vision API section when users follow a configuration link.
- Add markup and style regression coverage for the new behavior.

## Why

The long API forms dominated the settings page, and the fallback selector used a native macOS control style that did not match the rest of MEFinder's 2D interface.

## Validation

- 39 targeted settings and theme tests passed.
- The macOS release build's 58 packaging, PDFKit, preferences, and cross-platform tests passed.
- ZIP and DMG signatures, image integrity, and SHA-256 checks passed.
- Manually verified collapse and expand behavior, light and dark themes, the flat selector, configuration navigation focus, and PDFKit page jumping in the packaged app.
