### PR TITLE
Ignore macOS Finder metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist/
 release/
 data/
 test-output/
+.DS_Store
 *.sqlite3-*
 *.db-*
 


### PR DESCRIPTION
忽略本机自动生成的 `.DS_Store`，避免它再次出现在仓库清理状态中。