### PR TITLE
Use singular wording in README support prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 <p align="center">
-  如果 MEFinder 对你有帮助，欢迎点亮 ⭐ 支持我们！
+  如果 MEFinder 对你有帮助，欢迎点亮 ⭐ 支持我！
   <br>
   <a href="https://github.com/sabercomo/MEFinder/stargazers"><img src="https://img.shields.io/github/stars/sabercomo/MEFinder?style=social" alt="GitHub Stars"></a>
 </p>


### PR DESCRIPTION
## What changed

Changed the README support prompt from “支持我们” to “支持我”.

## Why

MEFinder is maintained by one person, so the singular wording accurately reflects the project.

## Impact

The GitHub repository homepage now addresses support for the individual maintainer.

## Checks

- `git diff --check`
